### PR TITLE
Add space to empty bash prompt example

### DIFF
--- a/_episodes/01-intro.md
+++ b/_episodes/01-intro.md
@@ -81,7 +81,7 @@ When the shell is first opened, you are presented with a **prompt**,
 indicating that the shell is waiting for input.
 
 ~~~
-$
+$ 
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
Without the space the jekyll page renders the result in red, possibly indicating an error.