### PR TITLE
Licenses and CfRR links

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,71 @@
+---
+layout: info_page
+title: Licenses
+---
+
+## Instructional Material
+
+This material is made available under the [Creative Commons Attribution
+license][cc-by-human].
+The following is a human-readable summary of (and not a substitute for) the
+[full legal text of the CC BY 4.0 license][cc-by-legal].
+
+You are free:
+
+- to **Share**---copy and redistribute the material in any medium or format
+- to **Adapt**---remix, transform, and build upon the material
+
+for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license
+terms.
+
+Under the following terms:
+
+- **Attribution**---You must give appropriate credit, provide a [link to the
+  license][cc-by-human], and indicate if changes were made.
+  You may do so in any reasonable manner, but not in any way that suggests the
+  licensor endorses you or your use.
+
+- **No additional restrictions**---You may not apply legal terms or
+technological measures that legally restrict others from doing anything the
+license permits.
+  With the understanding that:
+
+Notices:
+
+* You do not have to comply with the license for elements of the material in
+  the public domain or where your use is permitted by an applicable exception
+  or limitation.
+* No warranties are given.
+  The license may not give you all of the permissions necessary for your
+  intended use. For example, other rights such as publicity, privacy, or moral
+  rights may limit how you use the material.
+
+## Software
+
+Except where otherwise noted, the example programs and other software provided
+are made available under the [OSI][osi]-approved [MIT license][mit-license].
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+[cc-by-human]: https://creativecommons.org/licenses/by/4.0/
+[cc-by-legal]: https://creativecommons.org/licenses/by/4.0/legalcode
+[mit-license]: https://opensource.org/licenses/mit-license.html
+[osi]: https://opensource.org

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # Intro to unix shell
 
-Please find the deployed site [here](https://uniexeterrse.github.io/intro-unix-shell/).
+This course is now hosted by [Coding For Reproducible Research (CfRR)](https://coding-for-reproducible-research.github.io/).
+This material is still visible at [the deployed site](https://uniexeterrse.github.io/intro-unix-shell/), but any updates and new course dates will be found at [CfRR: Intro to Unix](https://coding-for-reproducible-research.github.io/CfRR_Courses/course_homepages/unix.html).
 These notes accompany in-person and online teaching during the two sessions of the Intro to Unix Shell course.
 
 ## Source details

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -3,5 +3,6 @@
   <a href="{{ site.url }}/code.html">Code of conduct</a>
   <a href="{{ site.url }}/setup.html">Installation guide</a>
   <a href="{{ site.url }}/contents.html">Course notes</a>
+  <a href="{{ site.url }}/license.html">Licenses</a>
   <a href="{{ site.url }}/resources.html">Resources</a>
 </div>

--- a/index.md
+++ b/index.md
@@ -3,6 +3,10 @@ layout: home
 title: Course Information
 ---
 
+## Notice
+
+This course is now hosted by [Coding For Reproducible Research](https://coding-for-reproducible-research.github.io/).
+
 ## Overview
 
 The Unix system and the shell predate most computational interfaces (e.g. the graphical user interface). Although very old, Unix based systems and the shell are one of the most powerful ways to use computers whether it is your laptop or a supercomputer. This course is an introduction to navigating your way around the shell and demonstrating how it can improve your workflow. This can be in the form of data processing, executing code, using a huge range of built-in tools, and creating pipelines.

--- a/index.md
+++ b/index.md
@@ -56,6 +56,8 @@ If you are interested in becoming part of our community of workshop helpers, lea
 
 ## Acknowledgements
 
-This course was adapted from Software Carpentries Intro to Unix Shell and has been developed by the University of Exeter Research Software Engineering Group who are enthusiastic about sharing their skills with the wider research community. Its provision is dependent on the time of these volunteers. If you have benefited in any way from this course and want to support its long term sustainability then please take the time to complete our feedback survey, recommend it to your colleagues, and enthuse about it to your senior leadership team.
+This course was adapted from [Software Carpentries](https://software-carpentry.org/) Intro to Unix Shell (now [Shell Novice](https://swcarpentry.github.io/shell-novice/)) and has been developed by the University of Exeter Research Software Engineering Group who are enthusiastic about sharing their skills with the wider research community.
+Its provision is dependent on the time of these volunteers.
+If you have benefited in any way from this course and want to support its long term sustainability then please take the time to complete our feedback survey, recommend it to your colleagues, and enthuse about it to your senior leadership team.
 
 This workshop is brought to you by the University of Exeter [Research Software Engineering Group](https://www.exeter.ac.uk/research/software-engineering/), University of Exeter [Institute of Data Science and Artificial Intelligence](https://www.exeter.ac.uk/research/idsai/), University of Exeter [Researcher Development](https://www.exeter.ac.uk/research/doctoralcollege/early-career-researchers/traininganddevelopment/rdprogramme/) and the University of Exeter [Doctoral College](https://www.exeter.ac.uk/research/doctoralcollege/).


### PR DESCRIPTION
Course is now hosted by CfRR.  This is reflected in the index and README.

Licenses and attribution added for the original software carpentries material.